### PR TITLE
Add in ability to use -output within the CLI to specify output file l…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 lib
 example/dist
+node_modules
+.idea
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Sometimes you'll need to pass `html-dist` some extra information, such as the lo
 The CLI lets you pass in any arbitrary arguments:
 
 ```
-./html-dist --config my.config.js --input index.html --jsFile "bundle-1234.js"
+./html-dist --config my.config.js --input index.html --output dist/index.html --jsFile "bundle-1234.js"
 ```
 
 In `my.config.js`, I can import `args` and have access to them:

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -12,6 +12,7 @@ var userArgs = _.omit(argv, ['config', 'input', '$0', '_']);
 fs.readFile(argv.input, {
   encoding: 'utf8'
 }, function(err, input) {
+
   // must be done before requiring the config file
   htmlDist.setUserArgs(userArgs);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-dist",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Generates HTML with your minified JavaScript in it",
   "repository": {
     "type": "git",

--- a/src/run.js
+++ b/src/run.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 
+import { args } from './index';
 import { fromHtml, toHtml, getDoctype } from './html';
 import { processTree } from './process-tree';
 import path from 'path';
@@ -50,9 +51,10 @@ export default function({ config, input }) {
     newHtml = html.prettyPrint(newHtml, { indent_size: 2 });
   }
 
-  if (config.outputFile) {
-    writeToFile(newHtml, config.outputFile);
-  } else {
+  if (config.outputFile || args.output) {
+    writeToFile(newHtml, ((config.outputFile) ? config.outputFile : args.output));
+  }
+  else {
     console.log(newHtml);
   }
 }


### PR DESCRIPTION
…ocation (overwritten if within html-dist.config.js)