### PR TITLE
Quick fix for node 10

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -64,7 +64,7 @@ function writeToFile(html, outfile) {
   mkdirp(dirsToMake, function(e) {
     // TODO: deal with error here
     console.log('Wrote to', outfile);
-    fs.writeFile(outfile, html);
+    fs.writeFileSync(outfile, html);
   });
 
 }


### PR DESCRIPTION
run.js: use writeFileSync instead of writeFile without callback.